### PR TITLE
Sin-cos fixes, additional interval functions

### DIFF
--- a/zonopy/contset/interval/interval.py
+++ b/zonopy/contset/interval/interval.py
@@ -154,6 +154,17 @@ class interval:
         intv_repr = intv_repr1.replace('tensor(','   inf(') + intv_repr2.replace('tensor(','   sup(')
         intv_repr = intv_repr.replace('    ','    ')
         return intv_repr+"\n   )"
+    
+    def __abs__(self):
+        '''
+        Overloaded unary operator for absolute value of an interval
+        self: <interval>
+        return <interval>
+        '''   
+        inf = torch.max(torch.stack([torch.zeros_like(self.__inf), self.__inf, -self.__sup]), dim=0).values
+        sup = torch.max(torch.stack([self.__sup, -self.__inf, torch.zeros_like(self.__sup)]), dim=0).values
+        return interval(inf,sup)
+
     def __add__(self, other):
         '''
         Overloaded '+' operator for addition or Minkowski sum

--- a/zonopy/math/transcendental.py
+++ b/zonopy/math/transcendental.py
@@ -348,12 +348,13 @@ def _int_cos_script(inf, sup):
     reg3 = torch.logical_and(upper < pi_twice + torch.pi, ~reg2)
     reg3_180 = torch.logical_and(reg3, nom_180)
     reg3_180_num = reg3_180.long()
-    out_low[4] = reg3_180_num * torch.cos(torch.minimum(pi_twice-upper, lower))
+    out_low[4] = reg3_180_num * torch.cos(torch.minimum(pi_twice-upper, lower-pi_twice))
     out_high[4] = reg3_180_num
     
     # Region 4, 360 < upper, lower < 180
     reg4 = torch.logical_or(reg1, reg2)
     reg4 = ~torch.logical_or(reg4, reg3_180)
+    reg4 = torch.logical_and(reg4, not_full_period)
     reg4_num = reg4.long()
     out_low[5] = -reg4_num
     out_high[5] = reg4_num


### PR DESCRIPTION
`sin` and `cos` have small errors in implementation.

The core function `zonopy.math.transcendental._int_cos_script`, which batch computes `cos` for intervals has two errors, where `inf_ = inf - 2pi*n` and `sup_ = sup-2pi*n` and `n = floor(inf/2pi)`:
* In the range of `inf_ in [pi, 2pi)`, `sup_ in [2pi, 3pi)`
it should compute `cos(min(2pi-sup, inf-2pi))` for the resulting inf value, but it was instead computing `cos(min(2pi-sup, inf))`.
* For `inf_ in [0,pi)`, `sup_ in [2pi, 3pi)`, if `sup-inf > 2pi`, this returned `{-2, 2}` due to double counting the 2pi condition.

Additionally, absolute value and division operations are implemented for intervals.